### PR TITLE
Fix an underflow that I encountered when uncompressing a tar file incrementally.

### DIFF
--- a/src/tarlib.cpp
+++ b/src/tarlib.cpp
@@ -188,7 +188,11 @@ internal::put( tar_stream& strm, bool continueAfterHeader ) {
 
 				return strm.len_out;
 			} else {
-				const uInt leftPadding = static_cast<decltype(_endPadding)>( _left );
+				uInt leftPadding = static_cast<decltype(_endPadding)>( _left );
+
+				if ( leftPadding > strm.avail_in )
+					leftPadding = strm.avail_in;
+
 				// Consume the padding but do not generate output
 				strm.len_out    = 0;
 				strm.total_out += leftPadding;


### PR DESCRIPTION
The fix is a bit of a guess but seems to work.
